### PR TITLE
Attempt to address #35

### DIFF
--- a/public/scripts/libs/Noduino.Socket.js
+++ b/public/scripts/libs/Noduino.Socket.js
@@ -102,8 +102,10 @@ define(function(require, exports, module) {
   }
   
   SocketNoduino.prototype.write = function(cmd, callback) {
+    var that = this;
+    var connectedSocket = that.io;
     this.log('info', 'writing: ' + cmd);
-    this.pushSocket('serial', {'type': 'write', 'write': cmd, 'id': this.io.socket.sessionid});
+    this.pushSocket('serial', {'type': 'write', 'write': cmd, 'id': connectedSocket.io.engine.id});
   };
 
   SocketNoduino.prototype.pinMode = function(pin, val) {

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -5,7 +5,6 @@ html(lang="en")
     link(rel="stylesheet", href="styles/bootstrap/init.css")
     link(rel="stylesheet", href="styles/prettify.css")
     link(rel="stylesheet", href="styles/init.css")
-    script(data-main="scripts/app." + jsApp, type="text/javascript", src="scripts/vendor/require-jquery.js")
     script(type="text/javascript", src="//" + hostname + ":8090/socket.io/socket.io.js")
   body
     .navbar.navbar-fixed-top(style="z-index: 4;position:absolute;")
@@ -55,3 +54,4 @@ html(lang="en")
           | . Layout based on 
           a(href="http://twitter.github.com/bootstrap/") twitter bootstrap framework
           | . 
+    script(data-main="scripts/app." + jsApp, type="text/javascript", src="scripts/vendor/require-jquery.js")


### PR DESCRIPTION
making sure socket io loads client side before all other scrips are loaded and try to connect to sockets, making session id in sockets compatible with socket io 1.0

I was having the same problems as in #35, where the io object was not defined before sockets was call in scripts loaded by the require-jquery script so I moved the script loader to the bottom of the index layout file.

Additionally, client side was mad at me about the socket session id when I tried the blinking light demo on the front page.  I made an update to Noduino.Socket.js to use socket.io.engine.id as in socket v 1.0 and above.

This library is awesome!
